### PR TITLE
Isolate full html pages

### DIFF
--- a/R/display.R
+++ b/R/display.R
@@ -59,6 +59,21 @@ display_raw <- function(mimetype, isbinary, data, file, metadata = NULL) {
     content <- prepare_content(isbinary, data, file)
     bundle <- list()
     bundle[[mimetype]] <- content
+    # Isolating full html pages (putting them in an iframe)
+    if (identical(mimetype, 'text/html')) {
+        if (grepl('<html.*>', content, ignore.case = TRUE)) {
+            if (is.null(metadata)) {
+                metadata <- namedlist()
+            }
+            html_md <- metadata[[mimetype]]
+            if (is.null(html_md)) {
+                html_md <- list(isolated = TRUE)
+            } else {
+                html_md[['isolated']] <- TRUE
+            }
+            metadata[[mimetype]] <- html_md
+        }
+    }
     publish_mimebundle(bundle, metadata)
 }
 

--- a/tests/testthat/test_display_functions.r
+++ b/tests/testthat/test_display_functions.r
@@ -69,6 +69,16 @@ test_that('display_html works', {
     expect_equal(get_last_data(), list(exp, NULL))
 })
 
+test_that('display_html with full html page', {
+    exp <- namedlist()
+    exp_md <- namedlist()
+    display_html('<html><body>text</body></html>')
+    exp[['text/html']] <- '<html><body>text</body></html>'
+    exp_md[['text/html']] <- list(isolated = TRUE)
+    expect_equal(get_last_data(),list(exp, exp_md))
+})
+
+
 test_that('display_markdown works', {
     exp <- namedlist()
     display_markdown('data')


### PR DESCRIPTION
This is similar how the IRkernel does it if it encounters a complete html page.

Closes: https://github.com/IRkernel/IRdisplay/issues/19
