### PR TITLE
Let display() use every available format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Authors@R: c(person("Thomas", "Kluyver", role = c("aut"), email = "thomas@kluyve
 Depends:
     R (>= 3.0.1)
 Suggests:
-	testthat
+	testthat,
+	withr
 Imports:
     repr,
     base64enc

--- a/R/display.R
+++ b/R/display.R
@@ -20,15 +20,11 @@ publish_mimebundle <- function(data, metadata=NULL) {
 #' @param obj  The object to be displayed
 #' @importFrom repr mime2repr repr_text
 #' @export
-display <- function (obj) {
+display <- function(obj) {
     data <- namedlist()
-    if (getOption('jupyter.rich_display')) {
-        for (mime in getOption('jupyter.display_mimetypes')) {
-            r <- mime2repr[[mime]](obj)
-            if (!is.null(r)) data[[mime]] <- r
-        }
-    } else {
-        data[['text/plain']] <- repr_text(obj)
+    for (mime in getOption('jupyter.display_mimetypes')) {
+        r <- mime2repr[[mime]](obj)
+        if (!is.null(r)) data[[mime]] <- r
     }
     publish_mimebundle(data)
 }

--- a/tests/testthat/test-options.r
+++ b/tests/testthat/test-options.r
@@ -1,7 +1,7 @@
 context('default options')
 
 test_that('default options are set', {
-  expect_true(getOption('jupyter.rich_display'))
-  expect_equal(length(getOption('jupyter.display_mimetypes')), 10)
+    expect_true(getOption('jupyter.rich_display'))
+    expect_equal(length(getOption('jupyter.display_mimetypes')), 10)
 })
 

--- a/tests/testthat/test_display_functions.r
+++ b/tests/testthat/test_display_functions.r
@@ -33,12 +33,19 @@ test_that('publish_mimebundle works', {
 
 test_that('display works', {
     exp <- namedlist()
+    # NULL only displays in plain/text
     display(NULL)
     exp[['text/plain']] <- repr_text(NULL)
     expect_equal(get_last_data(), list(exp, NULL))
-    display(1)
+    # This displays in everything, but just test it with html and plain text
+    withr::with_options(
+        list(jupyter.display_mimetypes = c('text/plain', 'text/html')),
+        display(1)
+    )
     exp[['text/plain']] <- repr_text(1)
-    expect_equal(get_last_data(), list(exp, NULL))
+    exp[['text/html']] <- repr_html(1)
+    res = get_last_data()
+    expect_equal(res, list(exp, NULL))
 })
 
 test_that('display_raw works', {


### PR DESCRIPTION
The docstring says that it displays in every format, so make it actually do that
even if the user sets the rich display system to FALSE. This makes it possible
to rich display an object manually even if the kernel itself does not _auto_
rich display objects.

I will move the option to IRkernel, but to make it possible to use a newer IRdisplay with an older IRkernel, the actual option is still set here. This option should be removed later: https://github.com/IRkernel/IRdisplay/issues/30.

Closes: https://github.com/IRkernel/IRdisplay/issues/28
